### PR TITLE
Fix compatibility issues with sequel 5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,39 @@
+PATH
+  remote: .
+  specs:
+    sequel-redshift (0.0.1)
+      pg
+      sequel
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    pg (1.2.2)
+    rake (13.0.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
+    sequel (5.28.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler
+  rake
+  rspec
+  sequel-redshift!
+
+BUNDLED WITH
+   2.1.4

--- a/lib/sequel/adapters/redshift.rb
+++ b/lib/sequel/adapters/redshift.rb
@@ -4,6 +4,15 @@ module Sequel
   module Redshift
     include Postgres
 
+    class Dataset < Postgres::Dataset
+
+      # Redshift doesn't support RETURNING statement
+      def insert_returning_sql(sql)
+        # do nothing here
+        sql
+      end
+    end
+
     class Database < Postgres::Database
       set_adapter_scheme :redshift
 
@@ -17,15 +26,11 @@ module Sequel
         # redshift doesn't support serial type
         super.merge(serial: false)
       end
-    end
 
-    class Dataset < Postgres::Dataset
-      Database::DatasetClass = self
+      private
 
-      # Redshift doesn't support RETURNING statement
-      def insert_returning_sql(sql)
-        # do nothing here
-        sql
+      def dataset_class_default
+        Sequel::Redshift::Dataset
       end
     end
   end

--- a/lib/sequel/redshift/version.rb
+++ b/lib/sequel/redshift/version.rb
@@ -1,5 +1,5 @@
 module Sequel
   module Redshift
-    VERSION = "0.0.1"
+    VERSION = "0.2"
   end
 end

--- a/sequel-redshift.gemspec
+++ b/sequel-redshift.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pg"
   spec.add_dependency "sequel"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
- sequel gem was not able to find adapter dataset because of deprecated way of defining it.
- new way is to define private method: https://github.com/jeremyevans/sequel/blob/67cc4245227a6c01ecb20d0138aaf37b05a5aebc/doc/release_notes/4.46.0.txt#L222